### PR TITLE
Feat/bsc launchpad test

### DIFF
--- a/contracts/launchpad/TokenLaunchpad.sol
+++ b/contracts/launchpad/TokenLaunchpad.sol
@@ -122,6 +122,10 @@ abstract contract TokenLaunchpad is ITokenLaunchpad, OwnableUpgradeable, ERC721E
     return defaultValueParams[_token][_adapter];
   }
 
+  function getLaunchParams(IERC20 _token) public view returns (CreateParams memory params) {
+    return launchParams[_token];
+  }
+
   /// @inheritdoc ITokenLaunchpad
   function getTokenAdapter(IERC20 _token) public view returns (ICLMMAdapter) {
     return launchParams[_token].adapter;
@@ -186,7 +190,7 @@ abstract contract TokenLaunchpad is ITokenLaunchpad, OwnableUpgradeable, ERC721E
 
       _fundLaunchPools(token, p.launchPools, p.launchPoolAmounts, p.isPremium);
 
-      uint256 pendingBalance = p.fundingToken.balanceOf(address(this));
+      uint256 pendingBalance = token.balanceOf(address(this));
       token.approve(address(p.adapter), type(uint256).max);
       address pool = p.adapter.addSingleSidedLiquidity(
         ICLMMAdapter.AddLiquidityParams({

--- a/contracts/launchpad/clmm/adapters/BaseV3Adapter.sol
+++ b/contracts/launchpad/clmm/adapters/BaseV3Adapter.sol
@@ -114,8 +114,8 @@ abstract contract BaseV3Adapter is ICLMMAdapter {
     IClPool pool = _createPool(_params.tokenBase, _params.tokenQuote, _params.fee, sqrtPriceX96Launch);
 
     // calculate and add liquidity for the various tick ranges
-    _mintAndLock(_params.tokenBase, _params.tokenQuote, _params.tick0, _params.tick1, _params.fee, 800_000_000 ether, 0);
-    _mintAndLock(_params.tokenBase, _params.tokenQuote, _params.tick1, _params.tick2, _params.fee, 200_000_000 ether, 1);
+    _mintAndLock(_params.tokenBase, _params.tokenQuote, _params.tick0, _params.tick1, _params.fee, _params.totalAmount - _params.graduationAmount, 0);
+    _mintAndLock(_params.tokenBase, _params.tokenQuote, _params.tick1, _params.tick2, _params.fee, _params.graduationAmount, 1);
 
     return address(pool);
   }

--- a/test/TokenLaunchpadTest.sol
+++ b/test/TokenLaunchpadTest.sol
@@ -12,15 +12,18 @@ import {Test} from "lib/forge-std/src/Test.sol";
 contract TokenLaunchpadTest is Test {
   MockERC20 _weth;
   MockERC20 _maha;
+  MockERC20 _stakingToken;
   TokenLaunchpad _launchpad;
 
   address owner = makeAddr("owner");
   address whale = makeAddr("whale");
   address creator = makeAddr("creator");
+  address feeDestination = makeAddr("feeDestination");
 
   function _setUpBase() internal {
     _weth = new MockERC20("Wrapped Ether", "WETH", 18);
     _maha = new MockERC20("Maha", "MAHA", 18);
+    _stakingToken = new MockERC20("Staking Token", "STK", 18);
 
     vm.label(address(_weth), "weth");
     vm.label(address(_maha), "maha");

--- a/test/TokenLaunchpadTest.sol
+++ b/test/TokenLaunchpadTest.sol
@@ -9,38 +9,35 @@ import {IFreeUniV3LPLocker} from "contracts/interfaces/IFreeUniV3LPLocker.sol";
 import {MockERC20} from "contracts/mocks/MockERC20.sol";
 import {Test} from "lib/forge-std/src/Test.sol";
 
-import "forge-std/console.sol";
-
 contract TokenLaunchpadTest is Test {
   MockERC20 _weth;
   MockERC20 _maha;
   TokenLaunchpad _launchpad;
 
-  address _owner = makeAddr("owner");
-  address _whale = makeAddr("whale");
-  address _creator = makeAddr("creator");
+  address owner = makeAddr("owner");
+  address whale = makeAddr("whale");
+  address creator = makeAddr("creator");
 
   function _setUpBase() internal {
     _weth = new MockERC20("Wrapped Ether", "WETH", 18);
     _maha = new MockERC20("Maha", "MAHA", 18);
-    _launchpad = new TokenLaunchpad();
 
     vm.label(address(_weth), "weth");
     vm.label(address(_maha), "maha");
-    vm.deal(_owner, 1000 ether);
-    vm.deal(_whale, 1000 ether);
-    vm.deal(_creator, 1000 ether);
+    vm.deal(owner, 1000 ether);
+    vm.deal(whale, 1000 ether);
+    vm.deal(creator, 1000 ether);
 
     vm.deal(address(this), 100 ether);
   }
 
-  function _findValidTokenHash(string memory _name, string memory _symbol, address _creator, MockERC20 _quoteToken)
+  function findValidTokenHash(string memory _name, string memory _symbol, address _creator, MockERC20 _quoteToken)
     internal
     view
     returns (bytes32)
   {
     // Get the runtime bytecode of WAGMIEToken
-    bytes memory bytecode = type(WAGMIEToken).runtimeCode;
+    bytes memory bytecode = type(WAGMIEToken).creationCode;
 
     // Maximum number of attempts to find a valid address
     uint256 maxAttempts = 100;
@@ -57,7 +54,6 @@ contract TokenLaunchpadTest is Test {
       address target = address(uint160(uint256(hash)));
 
       if (target < address(_quoteToken)) {
-        console.log("Found valid salt after %d attempts", i + 1);
         return salt;
       }
     }


### PR DESCRIPTION
- Fixed salt generation for token creation
- Replace hardcoded liquidity values (800M and 200M) with dynamic values from the AddLiquidityParams struct. This allows for configurable liquidity distribution between launch and graduation ranges based on the parameters passed to the adapter.
- Fixed a critical bug where we were checking the funding token balance instead of the token balance when adding liquidity
- Added tests for premium tokens with custom parameters
- Added tests for non-premium tokens using default parameters
- Added tests for tokens with non-ETH funding tokens

